### PR TITLE
Adjust robocopy flags

### DIFF
--- a/faim_robocopy/robocopy.py
+++ b/faim_robocopy/robocopy.py
@@ -480,10 +480,7 @@ def build_robocopy_command(source, dest, exclude_files, include_files,
         ] + include_files)
 
     # previously known as "secure mode"
-    cmd.extend(["/r:1", "/w:30", "/dcopy:T", "/Z"])
-
-    # remove job header and summary from log, but be verbose about files.
-    cmd.extend(['/V', '/njh', '/njs'])
+    cmd.extend(["/r:1", "/w:30", "/dcopy:T"])
 
     # additional flags.
     if not _is_empty(additional_flags):


### PR DESCRIPTION
We avoid `/Z` because it apparently can slow down copying (see e.g. [this reddit post](https://www.reddit.com/r/sysadmin/comments/2eww9x/robocopy_slow_speed/cojmxa8?utm_source=share&utm_medium=web2x&context=3)).

In addition, let's revert logging options to the default, i.e. non-verbose but with header and summary.

Closes #4.
