### PR TITLE
Add default logging flags to default config

### DIFF
--- a/.faimrobocopy_default.ini
+++ b/.faimrobocopy_default.ini
@@ -15,7 +15,7 @@ delete_src = False
 omit_patterns = 
 time_interval_in_s = 30
 time_to_exit_in_s = 300
-custom_flags =
+custom_flags = /NDL /NP /V
 
 [logging]
 clean_older_than_ndays = 30

--- a/faim_robocopy/gui/settings_ui.py
+++ b/faim_robocopy/gui/settings_ui.py
@@ -65,7 +65,7 @@ SETTING_NAMES = {
                      'float', None),
         'custom_flags':
         SettingsItem(
-            'Additional flags (experimental)', 'str',
+            'Additional flags (e.g. for logging to a file, add: /LOG+:debug.log)', 'str',
             'Additional flags to be passed to robocopy. '
             'See the official robocopy doc for more information. '
             'Flags are passed "as-is". Use carefully.')


### PR DESCRIPTION
These flags, combined with `/LOG+:debug.log` in the local settings, should result in a log file useful for file transfer benchmarks at FMI.

In detail:
- /NDL: No Directory List - don't log directory names
- /NP: No Progress - don't display percentage copied
- /V: Verbose output - show skipped files